### PR TITLE
Improved callback support added Task support and passing SessionRecord

### DIFF
--- a/libsignal-protocol-dotnet-tests/SessionBuilderTest.cs
+++ b/libsignal-protocol-dotnet-tests/SessionBuilderTest.cs
@@ -1,4 +1,4 @@
-﻿/** 
+/** 
  * Copyright (C) 2016 langboost
  * 
  * This program is free software: you can redistribute it and/or modify
@@ -25,6 +25,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.Collections.Generic;
 using System.Text;
+using System.Threading.Tasks;
 
 namespace libsignal_test
 {
@@ -46,10 +47,11 @@ namespace libsignal_test
                 this.originalMessage = originalMessage;
             }
 
-            public void handlePlaintext(byte[] plaintext)
+            public Task handlePlaintext(byte[] plaintext, uint sessionVersion)
             {
                 Assert.AreEqual(originalMessage, Encoding.UTF8.GetString(plaintext));
                 Assert.IsFalse(bobStore.ContainsSession(ALICE_ADDRESS));
+                return Task.CompletedTask;
             }
         }
 
@@ -87,7 +89,7 @@ namespace libsignal_test
             bobStore.StoreSignedPreKey(22, new SignedPreKeyRecord(22, DateUtil.currentTimeMillis(), bobSignedPreKeyPair, bobSignedPreKeySignature));
 
             SessionCipher bobSessionCipher = new SessionCipher(bobStore, ALICE_ADDRESS);
-            byte[] plaintext = bobSessionCipher.decrypt(incomingMessage, new BobDecryptionCallback(bobStore, originalMessage));
+            byte[] plaintext = bobSessionCipher.decrypt(incomingMessage, new BobDecryptionCallback(bobStore, originalMessage)).Result;
 
             Assert.IsTrue(bobStore.ContainsSession(ALICE_ADDRESS));
             Assert.AreEqual((uint)3, bobStore.LoadSession(ALICE_ADDRESS).getSessionState().getSessionVersion());

--- a/libsignal-protocol-dotnet/DecryptionCallback.cs
+++ b/libsignal-protocol-dotnet/DecryptionCallback.cs
@@ -1,24 +1,25 @@
-﻿/** 
- * Copyright (C) 2016 smndtrl, langboost
- * 
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- * 
- * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
- */
-
+using libsignal.state;
+using System.Threading.Tasks;
+/** 
+* Copyright (C) 2016 smndtrl, langboost
+* 
+* This program is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+* 
+* You should have received a copy of the GNU General Public License
+* along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
 namespace libsignal
 {
     public interface DecryptionCallback
     {
-        void handlePlaintext(byte[] plaintext);
+        Task handlePlaintext(byte[] plaintext, uint sessionVersion);
     }
 }

--- a/libsignal-protocol-dotnet/groups/GroupCipher.cs
+++ b/libsignal-protocol-dotnet/groups/GroupCipher.cs
@@ -19,7 +19,9 @@ using System;
 using libsignal.groups.ratchet;
 using libsignal.groups.state;
 using libsignal.protocol;
+using libsignal.state;
 using libsignal.util;
+using System.Threading.Tasks;
 
 namespace libsignal.groups
 {
@@ -127,7 +129,7 @@ namespace libsignal.groups
 
                     byte[] plaintext = getPlainText(senderKey.getIv(), senderKey.getCipherKey(), senderKeyMessage.getCipherText());
 
-                    callback.handlePlaintext(plaintext);
+                    callback.handlePlaintext(plaintext, 931).Wait();//931 random as we don't have the real version
 
                     senderKeyStore.storeSenderKey(senderKeyId, record);
 
@@ -210,7 +212,8 @@ namespace libsignal.groups
 
         private class NullDecryptionCallback : DecryptionCallback
         {
-            public void handlePlaintext(byte[] plaintext) { }
-        }
+			public Task handlePlaintext(byte[] plaintext, uint sessionVersion) => Task.CompletedTask;
+
+		}
     }
 }


### PR DESCRIPTION
    This modifies the existing callback support to work with Task based callbacks.  It also passes the SessionRecord (when available) to the callback (as not yet committed for prekey), needed for protocol version check code that already exists).
This allows for signal-csharp/libsignal-service-dotnet#34